### PR TITLE
Drop machine-specific license parameters

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -6,7 +6,7 @@ buttontext:"Notifier"
     rollout RenderNotifyRollout "Render License Notifier" width:300
     (
         edittext licenseInput "License Key:" width:280
-        label machineLabel "Checking license..." width:280
+        label statusLabel "Checking license..." width:280
         checkbox notifyStart "Notify on render start"
 
         button saveBtn "Save settings" width:280
@@ -32,24 +32,24 @@ buttontext:"Notifier"
                     local json = parseJSON raw
                     if json != undefined then
                     (
-                        if json.status == "? valid" then
-                            machineLabel.text = json.machine_name
+                        if (findString json.status "valid") != undefined then
+                            statusLabel.text = "? License valid"
                         else
-                            machineLabel.text = "? License invalid"
+                            statusLabel.text = "? License invalid"
                     )
                 ) catch (
-                    machineLabel.text = "? Invalid server response"
+                    statusLabel.text = "? Invalid server response"
                 )
             )
             else
             (
-                machineLabel.text = "? Server not available"
+                statusLabel.text = "? Server not available"
             )
         )
 
         on licenseInput entered val do
         (
-            machineLabel.text = "Checking..."
+            statusLabel.text = "Checking..."
             checkLicense val
         )
 
@@ -57,7 +57,6 @@ buttontext:"Notifier"
         (
             local iniPath = getDir #userScripts + "\\render_license_config.ini"
             setINISetting iniPath "RenderLicense" "license_key" licenseInput.text
-            setINISetting iniPath "RenderLicense" "machine_name" machineLabel.text
             setINISetting iniPath "RenderLicense" "notify_start" (if notifyStart.checked then "true" else "false")
             messageBox ("? Settings saved!\n\nINI file:\n" + iniPath) title:"RenderLicenseApp"
         )
@@ -66,8 +65,11 @@ buttontext:"Notifier"
         (
             local iniPath = getDir #userScripts + "\\render_license_config.ini"
             licenseInput.text = getINISetting iniPath "RenderLicense" "license_key"
-            machineLabel.text = getINISetting iniPath "RenderLicense" "machine_name"
             notifyStart.checked = (getINISetting iniPath "RenderLicense" "notify_start") == "true"
+            if licenseInput.text != "" then (
+                statusLabel.text = "Checking..."
+                checkLicense licenseInput.text
+            )
         )
 
         on saveBtn pressed do saveSettings()
@@ -116,11 +118,10 @@ buttontext:"Notifier"
         local iniPath = getDir #userScripts + "\\render_license_config.ini"
         local notifyStart = getINISetting iniPath "RenderLicense" "notify_start"
         local license = getINISetting iniPath "RenderLicense" "license_key"
-        local machine = getINISetting iniPath "RenderLicense" "machine_name"
 
         if notifyStart == "true" then
         (
-            if machine != "? License invalid" then
+            if license != "" then
             (
                 local sceneName = if maxFileName != "" then maxFileName else "Untitled"
                 local cameraName = getRenderViewName()

--- a/server/api/license_router.py
+++ b/server/api/license_router.py
@@ -13,17 +13,17 @@ def get_db():
         db.close()
 
 @router.post("/create_license")
-def create_license(telegram_id: str, machine_name: str, license_key: str, db: Session = Depends(get_db)):
+def create_license(telegram_id: str, license_key: str, db: Session = Depends(get_db)):
     user = user_service.get_user_by_telegram_id(db, telegram_id)
     if not user:
         return {"error": "Пользователь не найден"}
 
-    license = license_service.create_license(db, license_key, machine_name, user)
+    license = license_service.create_license(db, license_key, user)
     return {"message": "🔑 Лицензия создана", "license_id": license.id}
 
 @router.get("/check_license")
 def check_license(license_key: str, db: Session = Depends(get_db)):
     license = license_service.get_license_by_key(db, license_key)
     if license:
-        return {"status": "✅ valid", "license_key": license.license_key, "machine_name": license.machine_name}
+        return {"status": "✅ valid", "license_key": license.license_key}
     return {"status": "❌ invalid"}

--- a/server/db/seed.py
+++ b/server/db/seed.py
@@ -17,8 +17,8 @@ session.add(user)
 session.commit()
 
 print("🔗 Привязываю лицензии...")
-license1 = License(license_key="abc123", machine_name="HomePC", user_id=user.id)
-license2 = License(license_key="def456", machine_name="WorkPC", user_id=user.id)
+license1 = License(license_key="abc123", user_id=user.id)
+license2 = License(license_key="def456", user_id=user.id)
 
 session.add_all([license1, license2])
 session.commit()

--- a/server/main.py
+++ b/server/main.py
@@ -23,7 +23,6 @@ app.include_router(admin_router)
 # Модель для рендера
 class RenderData(BaseModel):
     license_key: str
-    machine_name: str
     log: str
 
 @app.post("/api/render_notify")
@@ -35,10 +34,6 @@ async def handle_render_notify(data: RenderData):
         if not license:
             raise HTTPException(status_code=401, detail="❌ Недействительный ключ")
 
-        # Здесь предполагается, что у License есть поле machine_name — проверь это
-        if hasattr(license, "machine_name") and license.machine_name != data.machine_name:
-            raise HTTPException(status_code=403, detail="🚫 Машина не совпадает с лицензией")
-
         user = db.query(User).filter_by(id=license.user_id).first()
         if not user:
             raise HTTPException(status_code=404, detail="👤 Пользователь не найден")
@@ -47,7 +42,7 @@ async def handle_render_notify(data: RenderData):
 
     now = datetime.now()
     formatted = (
-        f"🖥️ {data.machine_name} завершила рендер\n"
+        "🎬 Рендер завершён\n"
         f"🕒 Время: {now.strftime('%H:%M')}\n"
         f"📅 Дата: {now.strftime('%d.%m.%Y')}\n"
         f"📝 Лог: {data.log}"

--- a/server/routes/render_notify.py
+++ b/server/routes/render_notify.py
@@ -13,13 +13,13 @@ bot = Bot(token=TG_TOKEN)
 
 # Временное хранилище лицензий (заменим позже на базу)
 license_registry = {
-    "abc123": {"machine": "HomePC", "tg_id": "670562262"},
-    "def456": {"machine": "RenderBox", "tg_id": "670562262"},
+    "abc123": {"tg_id": "670562262"},
+    "def456": {"tg_id": "670562262"},
 }
+
 
 class RenderData(BaseModel):
     license_key: str
-    machine_name: str
     log: str
 
 @router.post("/api/render_notify")
@@ -29,12 +29,9 @@ async def render_notify(data: RenderData):
     if not record:
         raise HTTPException(status_code=401, detail="❌ Недействительный ключ")
 
-    if record["machine"] != data.machine_name:
-        raise HTTPException(status_code=403, detail="🚫 Машина не соответствует лицензии")
-
     now = datetime.now()
     formatted = (
-        f"🖥️ {data.machine_name} завершила рендер\n"
+        "🎬 Рендер завершён\n"
         f"🕒 Время: {now.strftime('%H:%M')}\n"
         f"📅 Дата: {now.strftime('%d.%m.%Y')}\n"
         f"📝 Лог: {data.log}"

--- a/server/services/license_service.py
+++ b/server/services/license_service.py
@@ -2,8 +2,9 @@ from sqlalchemy.orm import Session
 from server.models.license import License
 from server.models.user import User
 
-def create_license(db: Session, license_key: str, machine_name: str, user: User):
-    license = License(license_key=license_key, machine_name=machine_name, user_id=user.id)
+
+def create_license(db: Session, license_key: str, user: User):
+    license = License(license_key=license_key, user_id=user.id)
     db.add(license)
     db.commit()
     db.refresh(license)


### PR DESCRIPTION
## Summary
- remove `machine_name` parameter from license creation and validation
- simplify render notification models and messages
- update sample data and client script to match new API

## Testing
- `python -m py_compile server/services/license_service.py server/api/license_router.py server/main.py server/routes/render_notify.py server/db/seed.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9d5a3dd608321a33446b4ba47be0c