### PR TITLE
Return validity flag in license endpoint and update client

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -30,12 +30,22 @@ buttontext:"Notifier"
 
                 try (
                     local json = parseJSON raw
-                    if json != undefined then
-                    (
-                        if json.valid == true then
-                            statusLabel.text = "? License valid"
-                        else
-                            statusLabel.text = "? License invalid"
+                    if json != undefined then (
+                        if json.valid != undefined then (
+                            if json.valid == true then
+                                statusLabel.text = "? License valid"
+                            else
+                                statusLabel.text = "? License invalid"
+                        ) else if json.status != undefined then (
+                            if json.status == "✅ valid" then
+                                statusLabel.text = "? License valid"
+                            else
+                                statusLabel.text = "? License invalid"
+                        ) else (
+                            statusLabel.text = "? Invalid server response"
+                        )
+                    ) else (
+                        statusLabel.text = "? Invalid server response"
                     )
                 ) catch (
                     statusLabel.text = "? Invalid server response"

--- a/server/api/license_router.py
+++ b/server/api/license_router.py
@@ -25,5 +25,9 @@ def create_license(telegram_id: str, license_key: str, db: Session = Depends(get
 def check_license(license_key: str, db: Session = Depends(get_db)):
     license = license_service.get_license_by_key(db, license_key)
     if license:
-        return {"status": "✅ valid", "license_key": license.license_key}
-    return {"status": "❌ invalid"}
+        return {
+            "status": "✅ valid",
+            "license_key": license.license_key,
+            "valid": True,
+        }
+    return {"status": "❌ invalid", "valid": False}


### PR DESCRIPTION
## Summary
- Add `valid` boolean to license check API responses
- Read `valid` flag in MaxScript client with fallback to legacy `status`

## Testing
- `pytest`
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68a9ddfa182c8321ab5026a2fcd6f494