### PR TITLE
Register license API router in FastAPI app

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -6,6 +6,7 @@ from telegram import Bot
 from datetime import datetime
 
 from server.admin.routes import admin_router
+from server.api import license_router
 from server.db.session import SessionLocal
 from server.models.license import License
 from server.models.user import User
@@ -19,6 +20,7 @@ app = FastAPI()
 
 # Подключаем админский роутер
 app.include_router(admin_router)
+app.include_router(license_router.router, prefix="/api")
 
 # Модель для рендера
 class RenderData(BaseModel):


### PR DESCRIPTION
## Summary
- add license API router to FastAPI app so `/api` endpoints are registered

## Testing
- `pytest`
- `python -m uvicorn server.main:app --host 127.0.0.1 --port 8000` *(fails: `jinja2 must be installed`)*


------
https://chatgpt.com/codex/tasks/task_e_68a9df95b44c8321a69c90779e35cb51