### PR TITLE
Add username column to users and API

### DIFF
--- a/migrations/versions/1c30a7905d50_add_username_column_to_users.py
+++ b/migrations/versions/1c30a7905d50_add_username_column_to_users.py
@@ -1,0 +1,29 @@
+"""add username column to users
+
+Revision ID: 1c30a7905d50
+Revises: 8c2b5e5d6b8f
+Create Date: 2025-02-14 00:00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1c30a7905d50"
+down_revision: Union[str, Sequence[str], None] = "8c2b5e5d6b8f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("username", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.drop_column("username")
+

--- a/server/api/user_router.py
+++ b/server/api/user_router.py
@@ -5,6 +5,7 @@ from server.services import user_service
 
 router = APIRouter()
 
+
 def get_db():
     db = SessionLocal()
     try:
@@ -12,11 +13,12 @@ def get_db():
     finally:
         db.close()
 
+
 @router.post("/register")
-def register_user(telegram_id: str, username: str, db: Session = Depends(get_db)):
+def register_user(telegram_id: str, username: str | None = None, db: Session = Depends(get_db)):
     user = user_service.get_user_by_telegram_id(db, telegram_id)
     if user:
-        return {"message": "👤 Пользователь уже существует"}
-    
+        return {"message": "👤 Пользователь уже существует", "id": user.id, "username": user.username}
+
     new_user = user_service.create_user(db, telegram_id, username)
-    return {"message": "✅ Пользователь зарегистрирован", "id": new_user.id}
+    return {"message": "✅ Пользователь зарегистрирован", "id": new_user.id, "username": new_user.username}

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, BigInteger
+from sqlalchemy import Column, Integer, BigInteger, String
 from sqlalchemy.orm import relationship
 from server.db.base_class import Base
 
@@ -7,6 +7,7 @@ class User(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     telegram_id = Column(BigInteger, unique=True, index=True, nullable=False)
+    username = Column(String, nullable=True)
 
     licenses = relationship(
         "License",

--- a/server/services/user_service.py
+++ b/server/services/user_service.py
@@ -1,10 +1,12 @@
 from sqlalchemy.orm import Session
 from server.models.user import User
 
+
 def get_user_by_telegram_id(db: Session, telegram_id: str):
     return db.query(User).filter(User.telegram_id == telegram_id).first()
 
-def create_user(db: Session, telegram_id: str, username: str):
+
+def create_user(db: Session, telegram_id: str, username: str | None = None):
     user = User(telegram_id=telegram_id, username=username)
     db.add(user)
     db.commit()


### PR DESCRIPTION
## Summary
- add nullable `username` column to `User` model
- expose optional `username` when registering users
- create Alembic migration for new `username` column

## Testing
- `pytest`
- `python -m alembic upgrade head` *(fails: No module named alembic)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0ec9e4948321849dca4d26f5b923