### PR TITLE
Fix admin template and add extend route

### DIFF
--- a/server/admin/routes.py
+++ b/server/admin/routes.py
@@ -76,6 +76,21 @@ def delete_license(license_key: str = Form(...)):
 
     return RedirectResponse(url="/admin", status_code=303)
 
+
+@admin_router.post("/admin/extend")
+def extend_license(license_key: str = Form(...)):
+    """Extend the validity of a license by 30 days."""
+    db = SessionLocal()
+    try:
+        license = db.query(License).filter_by(license_key=license_key).first()
+        if license:
+            license.valid_until += datetime.timedelta(days=30)
+            db.commit()
+    finally:
+        db.close()
+
+    return RedirectResponse(url="/admin", status_code=303)
+
 @admin_router.get("/admin/users", response_class=HTMLResponse)
 def admin_users(request: Request):
     db = SessionLocal()

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -42,23 +42,6 @@
   <a href="/admin/users" style="margin-left: 30px;">👤 Пользователи</a>
 </div>
 
-    <form method="get" action="/admin/" style="margin-bottom: 20px;">
-  <label for="status">Статус:</label>
-  <select name="status" id="status">
-    <option value="">Все</option>
-    <option value="active">Активные</option>
-    <option value="expired">Просроченные</option>
-  </select>
-
-  <label for="sort">Сортировка:</label>
-  <select name="sort" id="sort">
-    <option value="valid_until_asc">По сроку ↑</option>
-    <option value="valid_until_desc">По сроку ↓</option>
-  </select>
-
-  <button type="submit">Применить</button>
-</form>
-
 <h2>➕ Создать новую лицензию</h2>
 <form method="post" action="/admin/create" style="margin-bottom: 30px;">
     <label for="telegram_id">Telegram ID пользователя:</label>
@@ -117,7 +100,7 @@
                     <button type="submit">➕ 30 дн.</button>
                 </form>
                 {% endif %}
-            <td>
+            </td>
         </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
## Summary
- remove duplicate filter form in license list template
- fix missing closing <td> tag
- implement /admin/extend route to add 30 days to licenses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab10f372e083219bda7407a8662d53