### PR TITLE
Remove username dependencies from user logic

### DIFF
--- a/server/api/user_router.py
+++ b/server/api/user_router.py
@@ -15,10 +15,11 @@ def get_db():
 
 
 @router.post("/register")
-def register_user(telegram_id: str, username: str | None = None, db: Session = Depends(get_db)):
+def register_user(telegram_id: str, db: Session = Depends(get_db)):
+    """Register a new user by Telegram ID."""
     user = user_service.get_user_by_telegram_id(db, telegram_id)
     if user:
-        return {"message": "👤 Пользователь уже существует", "id": user.id, "username": user.username}
+        return {"message": "👤 Пользователь уже существует", "id": user.id}
 
-    new_user = user_service.create_user(db, telegram_id, username)
-    return {"message": "✅ Пользователь зарегистрирован", "id": new_user.id, "username": new_user.username}
+    new_user = user_service.create_user(db, telegram_id)
+    return {"message": "✅ Пользователь зарегистрирован", "id": new_user.id}

--- a/server/db/seed.py
+++ b/server/db/seed.py
@@ -12,7 +12,7 @@ with SessionLocal() as session:
     session.query(User).delete()
 
     print("➕ Добавляю пользователей...")
-    user = User(telegram_id="670562262", username="Usachev_LAB")
+    user = User(telegram_id="670562262")
     session.add(user)
     session.commit()
 

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, BigInteger, String
+from sqlalchemy import Column, Integer, BigInteger
 from sqlalchemy.orm import relationship
 from server.db.base_class import Base
 
@@ -7,8 +7,6 @@ class User(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     telegram_id = Column(BigInteger, unique=True, index=True, nullable=False)
-    username = Column(String, nullable=True)
-
     licenses = relationship(
         "License",
         back_populates="user",

--- a/server/services/user_service.py
+++ b/server/services/user_service.py
@@ -6,8 +6,9 @@ def get_user_by_telegram_id(db: Session, telegram_id: str):
     return db.query(User).filter(User.telegram_id == telegram_id).first()
 
 
-def create_user(db: Session, telegram_id: str, username: str | None = None):
-    user = User(telegram_id=telegram_id, username=username)
+def create_user(db: Session, telegram_id: str):
+    """Create a new user without relying on a username field."""
+    user = User(telegram_id=telegram_id)
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -100,7 +100,10 @@ async def pay_license(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def handle_payment_proof(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
     is_renewal = 'renew_license_id' in context.user_data
-    admin_msg = f"🧾 Новый платёж {'(продление)' if is_renewal else ''}\nОт: @{user.username or 'неизвестно'} (id: {user.id})"
+    admin_msg = (
+        f"🧾 Новый платёж {'(продление)' if is_renewal else ''}\n"
+        f"От: {user.full_name or 'неизвестно'} (id: {user.id})"
+    )
 
     button_callback = (
         f'confirm_renew_{context.user_data["renew_license_id"]}'


### PR DESCRIPTION
## Summary
- drop username usage when creating or registering users
- update bot notifications to avoid username
- align database seed and model with absence of username column

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab1189749c8321b4978a0bbe355e89