### PR TITLE
Add Makefile to run server and bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.RECIPEPREFIX := >
+.PHONY: server bot
+
+server:
+>uvicorn server.main:app --reload
+
+bot:
+>python -m telegram_bot.bot

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # RenderLicenseApp
-RenderLicenseApp
+
+## Running
+
+Start the FastAPI server:
+
+```bash
+make server
+```
+
+Start the Telegram bot:
+
+```bash
+make bot
+```
+
+The same commands are listed in `test.py` for quick reference.


### PR DESCRIPTION
## Summary
- Add Makefile targets to start FastAPI server and Telegram bot
- Document how to run the server and bot using the new Makefile

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab143605c88321a361e3c052ed591f