### PR TITLE
Enforce single license per Telegram user

### DIFF
--- a/debug_seed.py
+++ b/debug_seed.py
@@ -18,14 +18,18 @@ if not user:
 # Генерируем ключ
 key = hashlib.sha256(f"{user.telegram_id}-expired".encode()).hexdigest()[:16]
 
-# Создаём лицензию с истёкшим сроком
-expired_license = License(
-    user_id=user.id,
-    license_key=key,
-    valid_until=datetime.datetime.now() - datetime.timedelta(days=10)
-)
-
-db.add(expired_license)
+# Создаём или обновляем лицензию с истёкшим сроком
+expired_license = db.query(License).filter_by(user_id=user.id).first()
+if expired_license:
+    expired_license.license_key = key
+    expired_license.valid_until = datetime.datetime.now() - datetime.timedelta(days=10)
+else:
+    expired_license = License(
+        user_id=user.id,
+        license_key=key,
+        valid_until=datetime.datetime.now() - datetime.timedelta(days=10),
+    )
+    db.add(expired_license)
 db.commit()
 db.close()
 

--- a/migrations/versions/9b8b5a76b3e4_enforce_single_license_per_user.py
+++ b/migrations/versions/9b8b5a76b3e4_enforce_single_license_per_user.py
@@ -1,0 +1,24 @@
+"""enforce single license per user
+
+Revision ID: 9b8b5a76b3e4
+Revises: 8c2b5e5d6b8f
+Create Date: 2025-09-24 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '9b8b5a76b3e4'
+down_revision: Union[str, Sequence[str], None] = '8c2b5e5d6b8f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    with op.batch_alter_table('licenses', schema=None) as batch_op:
+        batch_op.create_unique_constraint('uq_licenses_user_id', ['user_id'])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('licenses', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_licenses_user_id', type_='unique')

--- a/server/admin/routes.py
+++ b/server/admin/routes.py
@@ -142,13 +142,18 @@ def create_license(telegram_id: str = Form(...), days: int = Form(...)):
         license_key = str(uuid.uuid4())[:16]  # Короткий ключ, можно заменить на другой формат
         valid_until = datetime.datetime.now() + datetime.timedelta(days=days)
 
-        new_license = License(
-            license_key=license_key,
-            valid_until=valid_until,
-            user_id=user.id
-        )
+        existing = db.query(License).filter_by(user_id=user.id).first()
+        if existing:
+            existing.license_key = license_key
+            existing.valid_until = valid_until
+        else:
+            new_license = License(
+                license_key=license_key,
+                valid_until=valid_until,
+                user_id=user.id
+            )
+            db.add(new_license)
 
-        db.add(new_license)
         db.commit()
 
     finally:

--- a/server/db/seed.py
+++ b/server/db/seed.py
@@ -16,12 +16,9 @@ with SessionLocal() as session:
     session.add(user)
     session.commit()
 
-    print("🔗 Привязываю лицензии...")
-    licenses = [
-        License(license_key=key, user_id=user.id)
-        for key in ("abc123", "def456")
-    ]
-    session.add_all(licenses)
+    print("🔗 Привязываю лицензию...")
+    license = License(license_key="abc123", user_id=user.id)
+    session.add(license)
     session.commit()
 
     print("✅ База данных успешно заполнена.")

--- a/server/models/license.py
+++ b/server/models/license.py
@@ -7,7 +7,7 @@ class License(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     license_key = Column(String, unique=True, index=True, nullable=False)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False)
     valid_until = Column(DateTime, nullable=True)
 
-    user = relationship("User", back_populates="licenses")
+    user = relationship("User", back_populates="license")

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -7,8 +7,9 @@ class User(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     telegram_id = Column(BigInteger, unique=True, index=True, nullable=False)
-    licenses = relationship(
+    license = relationship(
         "License",
         back_populates="user",
-        cascade="all, delete-orphan"
+        cascade="all, delete-orphan",
+        uselist=False,
     )

--- a/server/services/license_service.py
+++ b/server/services/license_service.py
@@ -3,9 +3,15 @@ from server.models.license import License
 from server.models.user import User
 
 
-def create_license(db: Session, license_key: str, user: User):
-    license = License(license_key=license_key, user_id=user.id)
-    db.add(license)
+def create_license(db: Session, license_key: str, user: User, valid_until=None):
+    license = db.query(License).filter_by(user_id=user.id).first()
+    if license:
+        license.license_key = license_key
+        if valid_until is not None:
+            license.valid_until = valid_until
+    else:
+        license = License(license_key=license_key, user_id=user.id, valid_until=valid_until)
+        db.add(license)
     db.commit()
     db.refresh(license)
     return license

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -141,8 +141,17 @@ async def grant_license(update: Update, context: ContextTypes.DEFAULT_TYPE):
             db.refresh(user)
 
         license_key = hashlib.sha256(f"{user_id}-{datetime.datetime.now()}".encode()).hexdigest()[:16]
-        lic = License(user_id=user.id, license_key=license_key, valid_until=datetime.datetime.now() + datetime.timedelta(days=30))
-        db.add(lic)
+        lic = db.query(License).filter_by(user_id=user.id).first()
+        if lic:
+            lic.license_key = license_key
+            lic.valid_until = datetime.datetime.now() + datetime.timedelta(days=30)
+        else:
+            lic = License(
+                user_id=user.id,
+                license_key=license_key,
+                valid_until=datetime.datetime.now() + datetime.timedelta(days=30),
+            )
+            db.add(lic)
         db.commit()
         await context.bot.send_message(
             chat_id=user_id,


### PR DESCRIPTION
## Summary
- Ensure each user can own only one license
- Update license creation logic in admin panel and bot to overwrite existing license
- Add migration enforcing unique user_id in licenses

## Testing
- `pytest`
- `python -m py_compile debug_seed.py server/admin/routes.py server/db/seed.py server/models/license.py server/models/user.py server/services/license_service.py telegram_bot/bot.py migrations/versions/9b8b5a76b3e4_enforce_single_license_per_user.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab19a6c3088321a4db84f14598f2d5