### PR TITLE
Improve license check waiting

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -20,7 +20,9 @@ buttontext:"Notifier"
             local cmd = "curl -s -o \"" + outputFile + "\" -w \"%{http_code}\" \"" + url + "\" > \"" + statusFile + "\""
             shellLaunch "cmd.exe" ("/C " + cmd)
 
-            sleep 0.5
+            -- wait for curl to finish writing files (max ~2 seconds)
+            for i = 1 to 20 while (not (doesFileExist statusFile)) do sleep 0.1
+            for i = 1 to 20 while (not (doesFileExist outputFile)) do sleep 0.1
 
             local httpCode = undefined
             if doesFileExist statusFile then


### PR DESCRIPTION
## Summary
- Make 3ds Max plugin wait until curl output files exist before parsing the JSON

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab2231bb808321b7ac18e86dcdd2af