### PR TITLE
Fix return statements in MAXScript UI interface

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -148,11 +148,11 @@ buttontext:"Notifier"
     local license = getINISetting iniPath "RenderLicense" "license_key"
 
     if license == "" do (
-    messageBox "❌ License is missing. Render is unavailable." title:"RenderLicenseApp"
-    return
-)
+        messageBox "❌ License is missing. Render is unavailable." title:"RenderLicenseApp"
+        return undefined
+    )
 
-    if notifyStart != "true" then return
+    if notifyStart != "true" then return undefined
 
     local sceneName
     if maxFileName != "" then


### PR DESCRIPTION
## Summary
- Replace bare `return` usages with `return undefined` in `ui_interface.ms` to comply with MAXScript syntax.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab29a11bb083219037e66f3525bb78