### PR TITLE
Fix undefined callback functions in MaxScript

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -3,6 +3,10 @@ category:"RenderLicenseApp"
 tooltip:"Render Notifier"
 buttontext:"Notifier"
 (
+    global renderLicense_onRenderStart
+    global renderLicense_onRenderEnd
+    global getRenderViewName
+
     rollout RenderNotifyRollout "Render License Notifier" width:300
     (
         edittext licenseInput "License Key:" width:280


### PR DESCRIPTION
## Summary
- Make render notification callback functions global in `ui_interface.ms` so 3ds Max callbacks can access them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2b09912c83218f035cf25aa30800