### PR TITLE
feat: apply notify preference immediately

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -13,8 +13,6 @@ buttontext:"Notifier"
         label statusLabel "Checking license..." width:280
         checkbox notifyStart "Notify on render start"
 
-        button saveBtn "Save settings" width:280
-
         fn checkLicense key =
         (
             local url = "http://127.0.0.1:8000/api/check_license?license_key=" + key
@@ -84,14 +82,15 @@ buttontext:"Notifier"
         (
             statusLabel.text = "Checking..."
             checkLicense val
+
+            local iniPath = getDir #userScripts + "\\render_license_config.ini"
+            setINISetting iniPath "RenderLicense" "license_key" val
         )
 
-        fn saveSettings =
+        on notifyStart changed state do
         (
             local iniPath = getDir #userScripts + "\\render_license_config.ini"
-            setINISetting iniPath "RenderLicense" "license_key" licenseInput.text
-            setINISetting iniPath "RenderLicense" "notify_start" (if notifyStart.checked then "true" else "false")
-            messageBox ("✅ Settings saved!\n\nINI file:\n" + iniPath) title:"RenderLicenseApp"
+            setINISetting iniPath "RenderLicense" "notify_start" (if state then "true" else "false")
         )
 
         fn loadSettings =
@@ -104,8 +103,6 @@ buttontext:"Notifier"
                 checkLicense licenseInput.text
             )
         )
-
-        on saveBtn pressed do saveSettings()
 
         on RenderNotifyRollout open do
         (


### PR DESCRIPTION
## Summary
- persist notify-on-start setting when checkbox changes
- remove manual settings save step

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab2d7544348321bfff0cdb1120ce06