### PR TITLE
Send render notifications to admin regardless of license

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from pydantic import BaseModel
 import os
 from dotenv import load_dotenv
@@ -17,6 +17,9 @@ load_dotenv()
 TG_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 bot = Bot(token=TG_TOKEN)
 
+# Telegram ID пользователя, который должен получать уведомления независимо от лицензии
+ADMIN_ID = 670562262
+
 app = FastAPI()
 
 # Подключаем админский роутер
@@ -31,16 +34,23 @@ class RenderData(BaseModel):
 
 @app.post("/api/render_notify")
 async def handle_render_notify(data: RenderData):
+    """Получает лог рендера и отправляет его в Telegram.
+
+    Уведомление всегда отправляется пользователю ADMIN_ID. Если по переданному
+    ключу найден владелец лицензии, сообщение дополнительно уходит ему.
+    Проверка лицензии не блокирует отправку уведомления, что позволяет
+    диагностировать проблемы отдельно от механизма лицензирования.
+    """
+
     db = SessionLocal()
+    user_chat_id = None
 
     try:
         license = db.query(License).filter_by(license_key=data.license_key).first()
-        if not license:
-            raise HTTPException(status_code=401, detail="❌ Недействительный ключ")
-
-        user = db.query(User).filter_by(id=license.user_id).first()
-        if not user:
-            raise HTTPException(status_code=404, detail="👤 Пользователь не найден")
+        if license:
+            user = db.query(User).filter_by(id=license.user_id).first()
+            if user:
+                user_chat_id = user.telegram_id
     finally:
         db.close()
 
@@ -52,5 +62,9 @@ async def handle_render_notify(data: RenderData):
         f"📝 Лог: {data.log}"
     )
 
-    await bot.send_message(chat_id=user.telegram_id, text=formatted)
+    # Отправляем уведомление пользователю, если он найден, и всегда админу
+    if user_chat_id:
+        await bot.send_message(chat_id=user_chat_id, text=formatted)
+    await bot.send_message(chat_id=ADMIN_ID, text=formatted)
+
     return {"status": "ok", "message": "Лог получен и отправлен в Telegram"}


### PR DESCRIPTION
## Summary
- Always send render logs to admin Telegram ID 670562262
- Send logs to license owner when available, but no longer block on missing license

## Testing
- `python -m py_compile server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac04c7412483219b5e3ad7a597fe04