### PR TITLE
fix: correct render log JSON construction

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -128,7 +128,7 @@ buttontext:"Notifier"
     (
         local escapedLog = renderLicense_escape logText
         local url = "http://127.0.0.1:8000/api/render_notify"
-        local json = "{\\\"license_key\\\":\\\"" + license + "\\\",\\\"log\\\":\\\"" + escapedLog + "\\\"}"
+        local json = "{\"license_key\":\"" + license + "\",\"log\":\"" + escapedLog + "\"}"
         
         try (
             local wc = dotNetObject "System.Net.WebClient"


### PR DESCRIPTION
## Summary
- build render log JSON without superfluous escape characters

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PYTHON' ...` (FastAPI TestClient; status 200)
- Attempted to run `uvicorn` server but missing dependency `jinja2` (installation blocked)


------
https://chatgpt.com/codex/tasks/task_e_68ac136f5f508321a75194f24396d0c2