### PR TITLE
Respect notify_start setting when logging

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -189,14 +189,17 @@ buttontext:"Notifier"
                     "📷 View: " + cameraName + "\n" +
                     "🚀 Render start: " + startTime + "\n"
 
-    if notifyStart == "true" do messageBox logText title:"RenderLicenseApp"
-    renderLicense_sendLog license logText
+    if notifyStart == "true" then (
+        messageBox logText title:"RenderLicenseApp"
+        renderLicense_sendLog license logText
+    )
 )
 
 
     fn renderLicense_onRenderEnd =
     (
         local iniPath = getDir #userScripts + "\\render_license_config.ini"
+        local notifyStart = getINISetting iniPath "RenderLicense" "notify_start"
         local license = getINISetting iniPath "RenderLicense" "license_key"
         if license == "" do (
             messageBox "⚠️ License is missing. Logging without key." title:"RenderLicenseApp"
@@ -210,8 +213,10 @@ buttontext:"Notifier"
                         "📷 View: " + cameraName + "\n" +
                         "⏰ Render finished: " + endTime + "\n"
 
-        messageBox logText title:"RenderLicenseApp"
-        renderLicense_sendLog license logText
+        if notifyStart == "true" then (
+            messageBox logText title:"RenderLicenseApp"
+            renderLicense_sendLog license logText
+        )
     )
 
     createDialog RenderNotifyRollout


### PR DESCRIPTION
## Summary
- only send render start log when notifications are enabled
- gate render end notifications and logs behind notify_start flag

## Testing
- `python - <<'PY' ... PY`
- `pytest >/tmp/pytest.log && cat /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68ac15f16acc8321b340a710678227a8