### PR TITLE
Ensure WebClient gets .NET string for render log

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -128,13 +128,14 @@ buttontext:"Notifier"
     (
         local escapedLog = renderLicense_escape logText
         local url = "http://127.0.0.1:8000/api/render_notify"
-        local json = format "{\"license_key\":\"%\",\"log\":\"%\"}" license escapedLog
-        
+        local json = "{\"license_key\":\"" + license + "\",\"log\":\"" + escapedLog + "\"}"
+        local netJson = dotNetObject "System.String" json
+
         try (
             local wc = dotNetObject "System.Net.WebClient"
             wc.Headers.Add "Content-Type" "application/json"
             wc.Encoding = (dotNetClass "System.Text.Encoding").UTF8
-            wc.UploadString url json
+            wc.UploadString url netJson
         ) catch (
             format "RenderLicense: failed to send log to server: %\n" (getCurrentException())
         )


### PR DESCRIPTION
## Summary
- Build JSON payload via string concatenation and wrap it in a .NET `String` before uploading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac1c62f1b88321bcacb359e03858ee