### PR TITLE
Send render log without server formatting

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -4,7 +4,6 @@ import os
 import logging
 from dotenv import load_dotenv
 from telegram import Bot
-from datetime import datetime
 
 from server.admin.routes import admin_router
 from server.api import license_router
@@ -62,13 +61,7 @@ async def handle_render_notify(data: RenderData):
     finally:
         db.close()
 
-    now = datetime.now()
-    formatted = (
-        "🎬 Рендер завершён\n"
-        f"🕒 Время: {now.strftime('%H:%M')}\n"
-        f"📅 Дата: {now.strftime('%d.%m.%Y')}\n"
-        f"📝 Лог: {data.log}"
-    )
+    formatted = data.log
 
     # Отправляем уведомление пользователю, если он найден, и всегда админу
     if bot:


### PR DESCRIPTION
## Summary
- Remove server-side formatting for render notifications and use log payload directly

## Testing
- `python -m py_compile server/main.py`
- ⚠️ `python -m uvicorn server.main:app --reload` *(missing dependency jinja2: `jinja2 must be installed to use Jinja2Templates`)*
- ⚠️ `pip install jinja2` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2484963c8321bfd05e6ba17cdcde