### PR TITLE
Send render log as UTF-8 JSON

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -129,13 +129,12 @@ buttontext:"Notifier"
         local escapedLog = renderLicense_escape logText
         local url = "http://127.0.0.1:8000/api/render_notify"
         local json = "{\"license_key\":\"" + license + "\",\"log\":\"" + escapedLog + "\"}"
-        local netJson = dotNetObject "System.String" json
         
         try (
             local wc = dotNetObject "System.Net.WebClient"
-            wc.Headers.Add "Content-Type" "application/json"
+            wc.Headers.Add "Content-Type" "application/json; charset=utf-8"
             wc.Encoding = (dotNetClass "System.Text.Encoding").UTF8
-            wc.UploadString url netJson
+            wc.UploadData url "POST" ((dotNetClass "System.Text.Encoding").UTF8.GetBytes json)
         ) catch (
             format "RenderLicense: failed to send log to server: %\n" (getCurrentException())
         )


### PR DESCRIPTION
## Summary
- Encode render logs as UTF-8 JSON and post bytes directly
- Include explicit charset in request headers to preserve emoji

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac27a1a00483219d21d7688193dc0e