### PR TITLE
Use ASCII status for license check

### DIFF
--- a/server/api/license_router.py
+++ b/server/api/license_router.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from server.db.session import SessionLocal
@@ -24,10 +25,12 @@ def create_license(telegram_id: int, license_key: str, db: Session = Depends(get
 @router.get("/check_license")
 def check_license(license_key: str, db: Session = Depends(get_db)):
     license = license_service.get_license_by_key(db, license_key)
-    if license:
+    if license and license.valid_until and license.valid_until > datetime.utcnow():
+        days_left = (license.valid_until - datetime.utcnow()).days
         return {
-            "status": "✅ valid",
+            "status": "valid",
             "license_key": license.license_key,
             "valid": True,
+            "days_left": days_left,
         }
-    return {"status": "❌ invalid", "valid": False}
+    return {"status": "invalid", "valid": False}


### PR DESCRIPTION
## Summary
- remove emoji from `/check_license` responses
- report remaining days until expiration when license is valid

## Testing
- `python -m pytest`
- `make server` *(fails: jinja2 must be installed to use Jinja2Templates)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2e0008788321a0110e5134eef662