### PR TITLE
chore: improve license validation handling

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -21,12 +21,17 @@ buttontext:"Notifier"
                 local wc = dotNetObject "System.Net.WebClient"
                 wc.Encoding = (dotNetClass "System.Text.Encoding").UTF8
                 local raw = wc.DownloadString url
-                local json = parseJSON raw
 
-                if json != undefined and json.valid != undefined and json.valid == true then
-                    statusLabel.text = "✅ License valid"
-                else
-                    statusLabel.text = "❌ License invalid"
+                local json = undefined
+                try json = parseJSON raw catch()
+                if json != undefined then (
+                    if isProperty json #valid and json.valid == true then
+                        statusLabel.text = "✅ License valid"
+                    else
+                        statusLabel.text = "❌ License invalid"
+                ) else (
+                    statusLabel.text = "❌ Invalid server response"
+                )
             )
             catch
             (


### PR DESCRIPTION
## Summary
- handle invalid server responses in license check
- avoid undefined property lookups when parsing JSON
- only show server not available for network errors

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac39b98a0c8321805f893edf569788