### PR TITLE
Expand license key to 36 characters

### DIFF
--- a/debug_seed.py
+++ b/debug_seed.py
@@ -3,7 +3,7 @@ from server.db.session import SessionLocal
 from server.models.license import License
 from server.models.user import User
 import datetime
-import hashlib
+import uuid
 
 db = SessionLocal()
 
@@ -16,7 +16,7 @@ if not user:
     db.refresh(user)
 
 # Генерируем ключ
-key = hashlib.sha256(f"{user.telegram_id}-expired".encode()).hexdigest()[:16]
+key = str(uuid.uuid4())
 
 # Создаём или обновляем лицензию с истёкшим сроком
 expired_license = db.query(License).filter_by(user_id=user.id).first()

--- a/migrations/versions/7855115cbd60_expand_license_key_to_36_chars.py
+++ b/migrations/versions/7855115cbd60_expand_license_key_to_36_chars.py
@@ -1,0 +1,28 @@
+"""expand license_key to 36 chars
+
+Revision ID: 7855115cbd60
+Revises: 9b8b5a76b3e4
+Create Date: 2024-01-01 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '7855115cbd60'
+down_revision: Union[str, Sequence[str], None] = '9b8b5a76b3e4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    with op.batch_alter_table("licenses") as batch_op:
+        batch_op.alter_column("license_key",
+                              existing_type=sa.String(length=16),
+                              type_=sa.String(length=36))
+
+def downgrade() -> None:
+    with op.batch_alter_table("licenses") as batch_op:
+        batch_op.alter_column("license_key",
+                              existing_type=sa.String(length=36),
+                              type_=sa.String(length=16))

--- a/server/admin/routes.py
+++ b/server/admin/routes.py
@@ -142,7 +142,7 @@ def create_license(telegram_id: int = Form(...), days: int = Form(...)):
             db.commit()
             db.refresh(user)
 
-        license_key = str(uuid.uuid4())[:16]  # Короткий ключ, можно заменить на другой формат
+        license_key = str(uuid.uuid4())
         valid_until = datetime.datetime.now() + datetime.timedelta(days=days)
 
         existing = db.query(License).filter_by(user_id=user.id).first()


### PR DESCRIPTION
## Summary
- expand generated admin license keys to full UUIDs
- migrate license key column from 16 to 36 characters
- update debug seed to produce full-length keys

## Testing
- `pytest`
- `alembic revision -m "expand license_key to 36 chars"` *(fails: command not found)*
- `alembic upgrade head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5419dbb48321860fa2c2a0aed7c6