### PR TITLE
fix: correct license input limit assignment

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -86,7 +86,7 @@ buttontext:"Notifier"
         on RenderNotifyRollout open do
         (
             loadSettings()
-            limitText licenseInput 64
+            licenseInput.limitText = 64
 
             callbacks.removeScripts id:#renderLicenseStart
             callbacks.removeScripts id:#renderLicenseEnd


### PR DESCRIPTION
## Summary
- use `limitText` property assignment for `licenseInput` in MaxScript rollout

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac55e138d48321b4801b197128bf34