### PR TITLE
Refactor license status parsing in MaxScript UI

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -25,28 +25,14 @@ buttontext:"Notifier"
                 wc.Encoding = (dotNetClass "System.Text.Encoding").UTF8
                 local raw = wc.DownloadString url
 
-                local json = undefined
-                try json = parseJSON raw catch()
-                if json != undefined and isProperty json #status then (
-                    case json.status of
-                    (
-                        "active": (
-                            messageBox "✅ License active"
-                            userIdLabel.text = "ID: " + json.user_id
-                        )
-                        "not_found": (
-                            messageBox "❌ License not found"
-                            userIdLabel.text = ""
-                        )
-                        "expired": (
-                            messageBox "⏳ License expired"
-                            userIdLabel.text = ""
-                        )
-                        default:
-                        (
-                            messageBox "❌ Invalid server response"
-                            userIdLabel.text = ""
-                        )
+                local json = (dotNetClass "Newtonsoft.Json.JsonConvert").DeserializeObject raw
+                if json != undefined do (
+                    local status = (json.Item["status"] as string)
+                    case status of (
+                        "active": (messageBox "✅ License active"; userIdLabel.text = "ID: " + (json.Item["user_id"] as string))
+                        "not_found": (messageBox "❌ License not found"; userIdLabel.text = "")
+                        "expired": (messageBox "⏳ License expired"; userIdLabel.text = "")
+                        default: (messageBox "❌ Invalid server response"; userIdLabel.text = "")
                     )
                 )
                 else (


### PR DESCRIPTION
## Summary
- Use `Newtonsoft.Json` to deserialize license check responses
- Replace `json.status` access with `json.Item["status"]` switch and show user ID

## Testing
- `PYTHONPATH=. python server/db/seed.py`
- `PYTHONPATH=. python - <<'PY'\nfrom server.api.license_router import check_license\nfrom server.db.session import SessionLocal\n\nsession = SessionLocal()\nprint(check_license('abc123', db=session))\nPY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad5db1231083218132b766a33d3eda