### PR TITLE
Fix admin notification for suspended license

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -4,6 +4,7 @@ import os
 import logging
 from dotenv import load_dotenv
 from telegram import Bot
+from telegram_bot.bot import ADMIN_ID
 
 from server.admin.routes import admin_router
 from server.api import license_router
@@ -68,7 +69,7 @@ async def handle_render_notify(data: RenderData):
             await bot.send_message(chat_id=user_chat_id, text=formatted)
         else:
             await bot.send_message(
-                chat_id=user_chat_id,
+                chat_id=ADMIN_ID,
                 text="Лицензия приостановлена. Пожалуйста, продлите лицензию",
             )
     else:


### PR DESCRIPTION
## Summary
- send suspended license warning to admin instead of user

## Testing
- `python -m pytest`
- `make server` *(fails: jinja2 must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5db428a08321bd55e3433bfc17b4