### PR TITLE
Load Newtonsoft.Json before using JsonConvert

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -25,6 +25,14 @@ buttontext:"Notifier"
                 wc.Encoding = (dotNetClass "System.Text.Encoding").UTF8
                 local raw = wc.DownloadString url
 
+                try (
+                    dotNet.loadAssembly "Newtonsoft.Json.dll"
+                ) catch (
+                    messageBox "❌ Missing dependency: Newtonsoft.Json.dll" title:"RenderLicenseApp"
+                    userIdLabel.text = ""
+                    return undefined
+                )
+
                 local json = (dotNetClass "Newtonsoft.Json.JsonConvert").DeserializeObject raw
                 if json != undefined then (
                     local status = (json.Item["status"] as string)


### PR DESCRIPTION
## Summary
- load Newtonsoft.Json assembly before using `JsonConvert`
- show a clear message when the assembly is missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad74cdac5c83218a5fbcc57b55419e