### PR TITLE
Improve license check exception handling

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -48,14 +48,15 @@ buttontext:"Notifier"
                     userIdLabel.text = ""
                 )
             )
-            catch ex do (
-    if (ex.GetType().Name == "System.Net.WebException") then
-        messageBox "🌐❌ No connection to server"
-    else (
-        format "Exception: %\n" ex
-        messageBox "Unknown error"
-    )
-)
+            catch (
+                local ex = getCurrentException()
+                if (ex != undefined and ex.GetType().Name == "System.Net.WebException") then
+                    messageBox "🌐❌ No connection to server"
+                else (
+                    format "Exception: %\n" ex
+                    messageBox "Unknown error"
+                )
+            )
 
         )
 


### PR DESCRIPTION
## Summary
- replace `catch ex` with `catch` and retrieve exception via `getCurrentException`
- handle network errors specifically and log unknown exceptions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad7c451df88321ae25aab8353e4609