### PR TITLE
refactor: handle exceptions in checkLicense

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -50,7 +50,8 @@ buttontext:"Notifier"
             )
             catch (
                 local ex = getCurrentException()
-                if (ex != undefined and ex.GetType().Name == "System.Net.WebException") then
+                local exType = if ex != undefined then ex.GetType().Name else ""
+                if exType == "System.Net.WebException" then
                     messageBox "🌐❌ No connection to server"
                 else (
                     format "Exception: %\n" ex


### PR DESCRIPTION
## Summary
- avoid MAXScript syntax error by storing exception type in a variable and comparing it against `System.Net.WebException`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad6afdf8c88321a00283f39b9ce0a8