### PR TITLE
Allow expiring licenses from admin panel

### DIFF
--- a/server/admin/routes.py
+++ b/server/admin/routes.py
@@ -80,6 +80,21 @@ def delete_license(license_key: str = Form(...)):
     return RedirectResponse(url="/admin", status_code=303)
 
 
+@admin_router.post("/admin/expire")
+def expire_license(license_key: str = Form(...)):
+    """Mark the license as expired by setting its validity in the past."""
+    db = SessionLocal()
+    try:
+        license = db.query(License).filter_by(license_key=license_key).first()
+        if license:
+            license.valid_until = datetime.datetime.now() - datetime.timedelta(seconds=1)
+            db.commit()
+    finally:
+        db.close()
+
+    return RedirectResponse(url="/admin", status_code=303)
+
+
 @admin_router.post("/admin/extend")
 def extend_license(license_key: str = Form(...)):
     """Extend the validity of a license by 30 days."""

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -93,7 +93,12 @@
                     <input type="hidden" name="license_key" value="{{ lic.key }}">
                     <button type="submit">🗑</button>
                 </form>
-                
+
+                <form method="post" action="/admin/expire" style="display:inline; margin-left: 5px;" onsubmit="return confirm('Сделать эту лицензию просроченной?');">
+                    <input type="hidden" name="license_key" value="{{ lic.key }}">
+                    <button type="submit">⛔ Просрочить</button>
+                </form>
+
                 {% if "Активна" in lic.status %}
                 <form method="post" action="/admin/extend" style="display:inline; margin-left: 5px;">
                     <input type="hidden" name="license_key" value="{{ lic.key }}">


### PR DESCRIPTION
## Summary
- Add `/admin/expire` endpoint to force a license expiration
- Add `⛔ Просрочить` button in admin dashboard for each license

## Testing
- `python -m py_compile server/admin/routes.py`
- `python dev_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad91536bdc8321bcd6ec6e222f830e