### PR TITLE
Notify admin when license granted

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -145,6 +145,10 @@ async def grant_license(update: Update, context: ContextTypes.DEFAULT_TYPE):
                  "Вы можете просмотреть её в разделе 🔐 <b>«Лицензии»</b>."),
             parse_mode="HTML")
         await send_main_menu(user_id, context)
+        await context.bot.send_message(
+            chat_id=ADMIN_ID,
+            text=f"Пользователь {user_id} получил свою лицензию"
+        )
         await query.edit_message_text("✅ Лицензия выдана.")
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- Send admin an alert when a user receives their license

## Testing
- `pytest -q`
- `python -m py_compile telegram_bot/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea508670483218d28737fc1094d90