### PR TITLE
Adjust license duration controls in admin panel

### DIFF
--- a/server/admin/routes.py
+++ b/server/admin/routes.py
@@ -80,14 +80,14 @@ def delete_license(license_key: str = Form(...)):
     return RedirectResponse(url="/admin", status_code=303)
 
 
-@admin_router.post("/admin/expire")
-def expire_license(license_key: str = Form(...)):
-    """Mark the license as expired by setting its validity in the past."""
+@admin_router.post("/admin/reduce")
+def reduce_license(license_key: str = Form(...)):
+    """Reduce the validity of a license by 30 days."""
     db = SessionLocal()
     try:
         license = db.query(License).filter_by(license_key=license_key).first()
         if license:
-            license.valid_until = datetime.datetime.now() - datetime.timedelta(seconds=1)
+            license.valid_until -= datetime.timedelta(days=30)
             db.commit()
     finally:
         db.close()

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -94,17 +94,15 @@
                     <button type="submit">🗑</button>
                 </form>
 
-                <form method="post" action="/admin/expire" style="display:inline; margin-left: 5px;" onsubmit="return confirm('Сделать эту лицензию просроченной?');">
+                <form method="post" action="/admin/reduce" style="display:inline; margin-left: 5px;" onsubmit="return confirm('Уменьшить срок действия этой лицензии на 30 дней?');">
                     <input type="hidden" name="license_key" value="{{ lic.key }}">
-                    <button type="submit">⛔ Просрочить</button>
+                    <button type="submit">➖ 30 дн.</button>
                 </form>
 
-                {% if "Активна" in lic.status %}
                 <form method="post" action="/admin/extend" style="display:inline; margin-left: 5px;">
                     <input type="hidden" name="license_key" value="{{ lic.key }}">
                     <button type="submit">➕ 30 дн.</button>
                 </form>
-                {% endif %}
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- allow reducing a license's validity by 30 days
- always show extend button for licenses, even expired
- update admin panel button text and routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aea780902c832198d4425955b5388a