### PR TITLE
Handle referral start parameter in Telegram bot

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -36,11 +36,21 @@ async def send_main_menu(user_id, context):
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     tg_id = update.effective_user.id
+    start_param = context.args[0] if context.args else None
     db = SessionLocal()
     try:
         user = db.query(User).filter_by(telegram_id=tg_id).first()
         if not user:
-            user = User(telegram_id=tg_id, referral_code=str(uuid.uuid4()))
+            referred_by_id = None
+            if start_param:
+                referrer = db.query(User).filter_by(referral_code=start_param).first()
+                if referrer:
+                    referred_by_id = referrer.id
+            user = User(
+                telegram_id=tg_id,
+                referral_code=str(uuid.uuid4()),
+                referred_by_id=referred_by_id,
+            )
             db.add(user)
             db.commit()
         elif not user.referral_code:


### PR DESCRIPTION
## Summary
- Process /start command arguments to support referral codes
- Assign `referred_by_id` for newly created users when start parameter matches an existing user's referral code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aec14a3ec48321a85972725c1701e7