### PR TITLE
Add referral stats command to Telegram bot

### DIFF
--- a/server/services/referral_service.py
+++ b/server/services/referral_service.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from typing import List, Tuple
+
+from sqlalchemy.orm import Session
+
+from server.models.user import User
+from server.models.license import License
+
+
+def get_referrals_and_bonus_days(db: Session, user: User) -> Tuple[List[User], int]:
+    """Return successful referrals and remaining bonus days for the user."""
+    referrals = db.query(User).filter_by(
+        referred_by_id=user.id, referral_bonus_claimed=True
+    ).all()
+
+    license = db.query(License).filter_by(user_id=user.id).first()
+    days_left = 0
+    if license and license.valid_until:
+        days_left = max((license.valid_until - datetime.now()).days, 0)
+
+    return referrals, days_left


### PR DESCRIPTION
## Summary
- display successful referrals and remaining bonus days via new `referrals` command
- add "📊 Мои рефералы" button in main menu
- create referral service to fetch referral stats

## Testing
- `python -m py_compile telegram_bot/bot.py server/services/referral_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aec3fe5a148321952c69439f3583d3