### PR TITLE
Use async database session with absolute path

### DIFF
--- a/inspect_db.py
+++ b/inspect_db.py
@@ -1,7 +1,7 @@
 import sqlite3
-from server.db.session import SQLALCHEMY_DATABASE_URL
+from server.db.session import DATABASE_URL
 
-db_path = SQLALCHEMY_DATABASE_URL.replace("sqlite:///", "", 1)
+db_path = DATABASE_URL.replace("sqlite+aiosqlite:///", "", 1)
 
 conn = sqlite3.connect(db_path)
 cursor = conn.cursor()

--- a/server/admin/routes.py
+++ b/server/admin/routes.py
@@ -19,7 +19,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 templates = Jinja2Templates(directory=os.path.join(BASE_DIR, "templates"))
 
 @admin_router.get("/admin", response_class=HTMLResponse)
-
 async def admin_dashboard(
     request: Request, status: str = "", sort: str = "", q: str = ""
 ):
@@ -47,37 +46,12 @@ async def admin_dashboard(
         result = await db.execute(licenses_query)
         rows = result.all()
 
-<<<<<<< ours
-<<<<<<< ours
-    enriched_licenses = [
-        {
-            "key": lic.license_key,
-            "next_charge_at": lic.next_charge_at.strftime("%d.%m.%Y") if lic.next_charge_at else "—",
-            "user_id": user.telegram_id if user else "—",
-            "status": "✅ Активна" if lic.is_active else "❌ Неактивна",
-        }
-        for lic, user in licenses
-    ]
-
-    db.close()
-    return templates.TemplateResponse("index.html", {
-        "request": request,
-        "licenses": enriched_licenses,
-        "selected_status": status,
-        "selected_sort": sort,
-        "q": q
-    })
-=======
-=======
->>>>>>> theirs
     enriched_licenses = []
     for lic, user in rows:
         enriched_licenses.append(
             {
                 "key": lic.license_key,
-                "next_charge_at": lic.next_charge_at.strftime("%d.%m.%Y")
-                if lic.next_charge_at
-                else "—",
+                "next_charge_at": lic.next_charge_at.strftime("%d.%m.%Y") if lic.next_charge_at else "—",
                 "user_id": user.telegram_id if user else "—",
                 "status": "✅ Активна" if lic.is_active else "❌ Неактивна",
             }
@@ -93,10 +67,7 @@ async def admin_dashboard(
             "q": q,
         },
     )
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
+
 
 @admin_router.post("/admin/delete")
 async def delete_license(license_key: str = Form(...)):
@@ -138,29 +109,8 @@ async def extend_license(license_key: str = Form(...)):
 
     return RedirectResponse(url="/admin", status_code=303)
 
-@admin_router.get("/admin/users", response_class=HTMLResponse)
-<<<<<<< ours
-<<<<<<< ours
-def admin_users(request: Request):
-    db = SessionLocal()
-    users_query = (
-        db.query(User, func.count(License.id).label("license_count"))
-        .outerjoin(License, User.id == License.user_id)
-        .group_by(User.id)
-    )
-    user_data = [
-        {
-            "id": user.id,
-            "telegram_id": user.telegram_id,
-            "license_count": license_count,
-        }
-        for user, license_count in users_query.all()
-    ]
 
-    db.close()
-=======
-=======
->>>>>>> theirs
+@admin_router.get("/admin/users", response_class=HTMLResponse)
 async def admin_users(request: Request):
     async with SessionLocal() as db:
         result = await db.execute(select(User))
@@ -178,14 +128,11 @@ async def admin_users(request: Request):
                     "license_count": license_count,
                 }
             )
-<<<<<<< ours
->>>>>>> theirs
-=======
->>>>>>> theirs
 
     return templates.TemplateResponse(
         "users.html", {"request": request, "users": user_data}
     )
+
 
 @admin_router.post("/admin/users/delete")
 async def delete_user(user_id: int = Form(...)):

--- a/server/db/seed.py
+++ b/server/db/seed.py
@@ -3,11 +3,11 @@
 import asyncio
 from sqlalchemy import delete
 
-from server.db.session import SQLALCHEMY_DATABASE_URL, SessionLocal
+from server.db.session import DATABASE_URL, SessionLocal
 from server.models.license import License
 from server.models.user import User
 
-print(f"🗂 Используется база данных: {SQLALCHEMY_DATABASE_URL}")
+print(f"🗂 Используется база данных: {DATABASE_URL}")
 
 
 async def main() -> None:

--- a/server/db/session.py
+++ b/server/db/session.py
@@ -1,48 +1,18 @@
-<<<<<<< ours
-<<<<<<< ours
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from pathlib import Path
+"""Database session and engine setup using SQLAlchemy's async API."""
+
 import os
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 BASE_DIR = Path(__file__).resolve().parent
-SQLALCHEMY_DATABASE_URL = os.getenv(
-    "DATABASE_URL", f"sqlite:///{BASE_DIR / 'database.db'}"
+DATABASE_URL = os.getenv("DATABASE_URL", f"sqlite+aiosqlite:///{BASE_DIR / 'database.db'}")
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+SessionLocal = async_sessionmaker(
+    bind=engine,
+    expire_on_commit=False,
+    autocommit=False,
+    autoflush=False,
+    class_=AsyncSession,
 )
-
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-=======
-"""Database session and engine setup using SQLAlchemy's async API."""
-
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-
-
-SQLALCHEMY_DATABASE_URL = "sqlite+aiosqlite:///server/db/database.db"
-
-# Create an asynchronous engine and session factory. ``async_sessionmaker``
-# provides ``async with SessionLocal() as session`` usage throughout the code.
-engine = create_async_engine(SQLALCHEMY_DATABASE_URL, echo=False)
-SessionLocal = async_sessionmaker(  # type: ignore[call-arg]
-    bind=engine, expire_on_commit=False, autocommit=False, autoflush=False, class_=AsyncSession
-)
-
->>>>>>> theirs
-=======
-"""Database session and engine setup using SQLAlchemy's async API."""
-
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-
-
-SQLALCHEMY_DATABASE_URL = "sqlite+aiosqlite:///server/db/database.db"
-
-# Create an asynchronous engine and session factory. ``async_sessionmaker``
-# provides ``async with SessionLocal() as session`` usage throughout the code.
-engine = create_async_engine(SQLALCHEMY_DATABASE_URL, echo=False)
-SessionLocal = async_sessionmaker(  # type: ignore[call-arg]
-    bind=engine, expire_on_commit=False, autocommit=False, autoflush=False, class_=AsyncSession
-)
-
->>>>>>> theirs

--- a/test_sql.py
+++ b/test_sql.py
@@ -1,9 +1,9 @@
 import sqlite3
-from server.db.session import SQLALCHEMY_DATABASE_URL
+from server.db.session import DATABASE_URL
 
 print("🔍 Подключаюсь к БД...")
 
-db_path = SQLALCHEMY_DATABASE_URL.replace("sqlite:///", "", 1)
+db_path = DATABASE_URL.replace("sqlite+aiosqlite:///", "", 1)
 conn = sqlite3.connect(db_path)
 cursor = conn.cursor()
 


### PR DESCRIPTION
## Summary
- resolve merge conflicts in session setup and admin routes
- configure async SQLAlchemy engine via absolute DB path
- ensure SessionLocal is always used with `async with`
- update scripts to new `DATABASE_URL` constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68b00c1100548321a243b39ab6e1a37c