### PR TITLE
Use UTC for datetime comparisons

### DIFF
--- a/debug_seed.py
+++ b/debug_seed.py
@@ -26,12 +26,14 @@ async def main() -> None:
         expired_license = result.scalars().first()
         if expired_license:
             expired_license.license_key = key
-            expired_license.valid_until = datetime.datetime.now() - datetime.timedelta(days=10)
+            # Use UTC consistently with the application's time handling.
+            expired_license.valid_until = datetime.datetime.utcnow() - datetime.timedelta(days=10)
         else:
             expired_license = License(
                 user_id=user.id,
                 license_key=key,
-                valid_until=datetime.datetime.now() - datetime.timedelta(days=10),
+                # Maintain UTC for consistency across the codebase.
+                valid_until=datetime.datetime.utcnow() - datetime.timedelta(days=10),
             )
             db.add(expired_license)
         await db.commit()

--- a/server/services/referral_service.py
+++ b/server/services/referral_service.py
@@ -23,6 +23,7 @@ async def get_referrals_and_bonus_days(
     license = result.scalars().first()
     days_left = 0
     if license and license.is_active and license.next_charge_at:
-        days_left = max((license.next_charge_at - datetime.now()).days, 0)
+        # Use UTC to avoid timezone-related inconsistencies.
+        days_left = max((license.next_charge_at - datetime.utcnow()).days, 0)
 
     return referrals, days_left


### PR DESCRIPTION
## Summary
- Replace `datetime.now()` with `datetime.utcnow()` in referral service to ensure consistent timezone usage
- Update debug database seeding script to use UTC and document time-handling strategy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `pip install aiosqlite` *(fails: Could not find a version that satisfies the requirement aiosqlite; 403 when downloading)*

------
https://chatgpt.com/codex/tasks/task_e_68b00ec387cc8321a75bd13dbfd0137d