### PR TITLE
Use scripts directory for JSON DLL and log path

### DIFF
--- a/maxscript/ui_interface.ms
+++ b/maxscript/ui_interface.ms
@@ -26,11 +26,14 @@ buttontext:"Notifier"
                 local raw = wc.DownloadString url
 
                 try (
-                    local jsonPath = getFilenamePath (getSourceFileName()) + "Newtonsoft.Json.dll"
+                    -- Build DLL path from a predefined scripts directory
+                    local dllDir = pathConfig.appendPath (getDir #scripts) "RenderLicenseApp"
+                    local jsonPath = pathConfig.appendPath dllDir "Newtonsoft.Json.dll"
+                    format "Loading Newtonsoft.Json.dll from: %\n" jsonPath
                     if doesFileExist jsonPath then (
                         dotNet.loadAssembly jsonPath
                     ) else (
-                        messageBox "❌ Newtonsoft.Json.dll not found" title:"RenderLicenseApp"
+                        messageBox ("❌ Newtonsoft.Json.dll not found:\n" + jsonPath) title:"RenderLicenseApp"
                         userIdLabel.text = ""
                         return undefined
                     )


### PR DESCRIPTION
## Summary
- Load Newtonsoft.Json.dll from a fixed scripts directory instead of using `getSourceFileName`
- Log the DLL path and verify its existence before calling `dotNet.loadAssembly`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `pip install aiosqlite` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b0547ccafc832184a6bd30b0fad084