### PR TITLE
Ensure Telegram bot token is required on startup

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -19,14 +19,11 @@ from sqlalchemy import select
 
 load_dotenv()
 TG_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
-
-bot = None
 if not TG_TOKEN:
-    logging.warning(
-        "TELEGRAM_BOT_TOKEN is not set; Telegram bot initialization skipped."
-    )
-else:
-    bot = Bot(token=TG_TOKEN)
+    logging.critical("TELEGRAM_BOT_TOKEN is not set; aborting startup")
+    raise RuntimeError("TELEGRAM_BOT_TOKEN environment variable is required")
+
+bot = Bot(token=TG_TOKEN)
 
 app = FastAPI()
 BASE_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
## Summary
- Require `TELEGRAM_BOT_TOKEN` after loading environment variables
- Log critical error and halt startup when token is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0597ed5688321958cec019a27071f