### PR TITLE
Initialize Telegram bot on startup and shutdown

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -24,8 +24,18 @@ if not TG_TOKEN:
     raise RuntimeError("TELEGRAM_BOT_TOKEN environment variable is required")
 
 bot = Bot(token=TG_TOKEN)
-
 app = FastAPI()
+
+
+@app.on_event("startup")
+async def startup_event():
+    await bot.initialize()
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    await bot.shutdown()
+
 BASE_DIR = Path(__file__).resolve().parent
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
 


### PR DESCRIPTION
## Summary
- initialize Telegram Bot during FastAPI startup and cleanly shut it down on app termination
- continue using the globally initialized bot in render notification handler

## Testing
- `TELEGRAM_BOT_TOKEN=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b138a7afa08321910faa5025fa4687