### PR TITLE
Make API base URL configurable for Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ make bot
 
 The same commands are listed in `test.py` for quick reference.
 
+## Deployment
+
+When deploying the Telegram bot, set the `API_BASE_URL` environment variable to the
+public base URL of the FastAPI service so that the bot can reach the API. Locally the
+bot defaults to `http://127.0.0.1:8000` when the variable is not provided.
+
 ## Database
 
 The application uses an SQLite database stored at `server/db/database.db` by default.

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -23,6 +23,8 @@ from server.services.referral_service import get_referrals_and_bonus_days
 
 load_dotenv()
 
+API_BASE = os.getenv("API_BASE_URL", "http://127.0.0.1:8000")
+
 
 def _load_bot_token() -> str:
     """Load and validate Telegram bot token from environment or .env.
@@ -212,7 +214,7 @@ async def subscribe_license(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         # Обращаемся к нашему FastAPI-эндпоинту, который создаёт платёж в ЮKassa
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(
-                "http://127.0.0.1:8000/api/create_payment",
+                f"{API_BASE}/api/create_payment",
                 json={"telegram_id": tg_id},
             )
 


### PR DESCRIPTION
## Summary
- read the API base URL for the Telegram bot from the `API_BASE_URL` environment variable and reuse it for payment requests
- document the need to set `API_BASE_URL` when deploying the bot so it can reach the FastAPI service

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c91f0cd6688321a203abf934cad452