### PR TITLE
Remove bonus days line from referral message

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -196,7 +196,6 @@ async def show_referrals(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     lines = "\n".join(f"• {r.telegram_id}" for r in referrals)
     msg = (
         f"Количество приглашённых: {len(referrals)}\n"
-        f"Бонусных дней доступно: {bonus_days_available}\n"
         f"Начислено бонусных дней за всё время: {total_bonus_days}"
     )
     if lines:


### PR DESCRIPTION
## Summary
- remove the bonus days available line from the referral summary message so the output no longer mentions that value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c94563dc048321b28c10887aaa7237