### PR TITLE
Adjust referral list display

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -199,7 +199,7 @@ async def show_referrals(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         f"Начислено бонусных дней за всё время: {total_bonus_days}"
     )
     if lines:
-        msg += f"\n\nПриглашённые пользователи:\n{lines}"
+        msg += f"\n\n{lines}"
     else:
         msg += "\n\nПока нет приглашённых пользователей."
 


### PR DESCRIPTION
## Summary
- remove the referral list header so only the invited Telegram IDs are displayed in the referral view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c945e0166c83218ef74e0486f33500