### PR TITLE
Adjust referral message to omit user IDs

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -193,14 +193,11 @@ async def show_referrals(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 db, user
             )
 
-    lines = "\n".join(f"• {r.telegram_id}" for r in referrals)
     msg = (
         f"Количество приглашённых: {len(referrals)}\n"
         f"Начислено бонусных дней за всё время: {total_bonus_days}"
     )
-    if lines:
-        msg += f"\n\n{lines}"
-    else:
+    if not referrals:
         msg += "\n\nПока нет приглашённых пользователей."
 
     keyboard = [[InlineKeyboardButton("⬅️ Назад", callback_data="back_to_main")]]


### PR DESCRIPTION
## Summary
- remove referral ID listing from the referral summary message
- keep the existing notice when no referrals are present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c94720b434832181d84742a10e6c67