### PR TITLE
Pin YooKassa dependency to a stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ make bot
 
 The same commands are listed in `test.py` for quick reference.
 
+## Dependencies
+
+- The YooKassa SDK is pinned to the stable release `yookassa==3.3.0` in `requirements.txt`
+  to protect the integration from backwards incompatible API changes.
+
 ## Deployment
 
 When deploying the Telegram bot, set the `API_BASE_URL` environment variable to the

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ typing_extensions==4.14.1
 urllib3==2.5.0
 uvicorn==0.35.0
 aiosqlite==0.20.0
-yookassa
+yookassa==3.3.0


### PR DESCRIPTION
## Summary
- pin the `yookassa` dependency to the stable release 3.3.0 in requirements.txt
- document the pinned version in the README for deployment awareness

## Testing
- python -m pip index versions yookassa *(fails: network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95448682c8321af28caaaa5267e39