### PR TITLE
Add production server Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .RECIPEPREFIX := >
 
-.PHONY: server bot
+.PHONY: server server-prod bot
 
 server:
 > uvicorn server.main:app --reload
+
+server-prod:
+> uvicorn server.main:app --host 0.0.0.0 --port 8000
 
 bot:
 > python -m telegram_bot.bot

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Start the FastAPI server:
 make server
 ```
 
+For a production deployment use:
+
+```bash
+make server-prod
+```
+
 Start the Telegram bot:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a `server-prod` make target for running the FastAPI app in production mode
- document the production command in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c955193e088321b0cc5c2ba1879204